### PR TITLE
remove repetitive build success notifications

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -44,4 +44,5 @@ mix
         'node_modules'
       ]
     }
-  });
+  })
+  .disableSuccessNotifications();


### PR DESCRIPTION
On Windows, the "Build successful" notifications from Laravel Mix can be a bit "spammy"

This commit removes the notification after 1 successful build, but still shows a notification if there's an error

Documentation: https://laravel-mix.com/docs/4.0/os-notifications

![pulse-browser_nCY8cMc6rF](https://user-images.githubusercontent.com/33391370/223987435-47a23a8a-91fd-4a11-b8f1-eac9ad0fa7c8.gif)